### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can do it by:
 npm install wdio-reportportal-reporter --save-dev
 ```
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
+Instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted).
 
 ## Configuration
 Configure the output directory in your wdio.conf.js file:


### PR DESCRIPTION
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

<img width="663" alt="Screen Shot 2022-12-16 at 1 24 30 PM" src="https://user-images.githubusercontent.com/8421048/208164565-86b9c578-30d6-4223-b131-2b2e5057c7c6.png">
